### PR TITLE
Default Encoding is added in the options

### DIFF
--- a/src/WebMarkupMin.AspNetCore1/BodyWrapperStream.cs
+++ b/src/WebMarkupMin.AspNetCore1/BodyWrapperStream.cs
@@ -267,7 +267,7 @@ namespace WebMarkupMin.AspNetCore2
 
 				if (cachedByteCount > 0 && _options.IsAllowableResponseSize(cachedByteCount))
 				{
-					Encoding encoding = _encoding ?? Encoding.GetEncoding(0);
+					Encoding encoding = _encoding ??_options.DeafultEncoding ?? Encoding.GetEncoding(0);
 					string content = encoding.GetString(cachedBytes);
 
 					IMarkupMinifier minifier = _currentMinificationManager.CreateMinifier();

--- a/src/WebMarkupMin.AspNetCore1/WebMarkupMinOptions.cs
+++ b/src/WebMarkupMin.AspNetCore1/WebMarkupMinOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System.Text;
+using Microsoft.AspNetCore.Hosting;
 
 using WebMarkupMin.AspNet.Common;
 
@@ -43,9 +44,12 @@ namespace WebMarkupMin.AspNetCore2
 			get;
 			set;
 		}
+        /// <summary>
+        /// Gets or sets the default encoding
+        /// </summary>
+        public Encoding DeafultEncoding { get; set; }
 
-
-		/// <summary>
+        /// <summary>
 		/// Constructs a instance of WebMarkupMin options
 		/// </summary>
 		public WebMarkupMinOptions()

--- a/src/WebMarkupMin.AspNetCore2/WebMarkupMin.AspNetCore2.csproj
+++ b/src/WebMarkupMin.AspNetCore2/WebMarkupMin.AspNetCore2.csproj
@@ -16,6 +16,10 @@
 2. Now, by default, the GZip algorithm has a higher priority than the Deflate.</PackageReleaseNotes>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	  <PlatformTarget>x64</PlatformTarget>
+	</PropertyGroup>
+
 	<Import Project="../../build/common.props" />
 	<Import Project="../../build/strong-name-signing.props" />
 	<Import Project="../../build/nuget-metadata.props" />
@@ -67,10 +71,7 @@
 	</ItemGroup>
 
 	<Target Name="СonvertResxToCs" BeforeTargets="BeforeCompile">
-		<ResxToCsTask
-			InputDirectory="./Resources/"
-			Namespace="$(RootNamespace).Resources"
-			InternalAccessModifier="true" />
+		<ResxToCsTask InputDirectory="./Resources/" Namespace="$(RootNamespace).Resources" InternalAccessModifier="true" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
When you have no control over the encoding of the response, it is not always a good idea to configure a charset by default, as it may conflict with the HTML charset Attribute. But it is good to be able to define what is the default encoding that WebMarkupMin will use. So that there are no inconsistencies between the operating systems.