### PR TITLE
Add WebMarkupMinServicesBuilder.Services property.

### DIFF
--- a/src/WebMarkupMin.AspNetCore1/WebMarkupMinServicesBuilder.cs
+++ b/src/WebMarkupMin.AspNetCore1/WebMarkupMinServicesBuilder.cs
@@ -22,6 +22,14 @@ namespace WebMarkupMin.AspNetCore5
 		/// <summary>
 		/// Collection of service descriptors
 		/// </summary>
+		public IServiceCollection Services
+		{
+			get
+			{
+				return _services;
+			}
+		}
+
 		private readonly IServiceCollection _services;
 
 


### PR DESCRIPTION
Mirrors e.g.: https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.imvcbuilder.services

This is necessary to fit `AddWebMarkupMin(...)` into an existing fluent pipeline without splitting it into multiple statements:

    services
        .AddMvc()
        .Services
        .AddRouting()
        .AddWebMarkupMin()
        .AddHtmlMinification()
        .Services
        .AddHttpClient()
        ...